### PR TITLE
Update cursor status on prompt

### DIFF
--- a/supabase/functions/workflow-automation/index.ts
+++ b/supabase/functions/workflow-automation/index.ts
@@ -225,13 +225,17 @@ async function automateTaskTransitions(workspaceId: string, entityId: string, en
       let statusChanged = false;
       let reason = '';
 
-      // Rule 1: "To Do" → "In Progress" when Cursor agent starts
+      // Rule 1: "To Do" → "In Progress" when Cursor agent starts (DISABLED)
+      // This rule was causing automatic status changes when prompts are sent to Cursor
+      // Uncomment the following lines if you want to re-enable automatic status transitions:
+      /*
       if (prompt.status === 'todo' && prompt.cursor_agent_id && 
           (prompt.cursor_agent_status === 'RUNNING' || prompt.cursor_agent_status === 'CREATING')) {
         updates.status = 'in_progress';
         statusChanged = true;
         reason = 'Cursor agent started working on task';
       }
+      */
 
       // Rule 2: "In Progress" → "Done" when PR is merged
       if ((prompt.status === 'in_progress' || prompt.status === 'pr_created') && 


### PR DESCRIPTION
Disable automatic "To Do" to "In Progress" status transition for prompts when a Cursor agent starts.

---
<a href="https://cursor.com/background-agent?bcId=bc-09fb93ba-1709-4fc7-9294-34323b5f1a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09fb93ba-1709-4fc7-9294-34323b5f1a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

