### PR TITLE
Update cursor status on prompt

### DIFF
--- a/src/components/MinimalPromptList.tsx
+++ b/src/components/MinimalPromptList.tsx
@@ -240,14 +240,14 @@ export function MinimalPromptList({
       const ok = await copyText(content);
       if (!ok) throw new Error('Clipboard copy failed');
       
-      // Auto-change status from todo to in_progress when copied
-      if (prompt.status === 'todo') {
-        await updatePromptStatus(prompt.id, 'in_progress');
-      }
+      // Auto-change status from todo to in_progress when copied - DISABLED
+      // if (prompt.status === 'todo') {
+      //   await updatePromptStatus(prompt.id, 'in_progress');
+      // }
       
       toast({
         title: 'Copied to clipboard',
-        description: prompt.status === 'todo' ? 'Prompt copied and moved to In Progress' : 'Prompt content has been copied'
+        description: 'Prompt content has been copied'
       });
     } catch (error) {
       console.error('Error copying to clipboard:', error);
@@ -278,10 +278,10 @@ export function MinimalPromptList({
         const ok = await copyText(prompt.generated_prompt);
         if (!ok) throw new Error('Clipboard copy failed');
         
-        // Auto-change status from todo to in_progress when copied
-        if (prompt.status === 'todo') {
-          await updatePromptStatus(prompt.id, 'in_progress');
-        }
+        // Auto-change status from todo to in_progress when copied - DISABLED
+        // if (prompt.status === 'todo') {
+        //   await updatePromptStatus(prompt.id, 'in_progress');
+        // }
         
         toast({
           title: 'Generated prompt copied',
@@ -308,10 +308,10 @@ export function MinimalPromptList({
         const ok = await copyText(response.transformedPrompt);
         if (!ok) throw new Error('Clipboard copy failed');
         
-        // Auto-change status from todo to in_progress when copied
-        if (prompt.status === 'todo') {
-          await updatePromptStatus(prompt.id, 'in_progress');
-        }
+        // Auto-change status from todo to in_progress when copied - DISABLED
+        // if (prompt.status === 'todo') {
+        //   await updatePromptStatus(prompt.id, 'in_progress');
+        // }
         
         toast({
           title: 'Generated prompt copied',

--- a/supabase/functions/workflow-automation/index.ts
+++ b/supabase/functions/workflow-automation/index.ts
@@ -98,24 +98,24 @@ async function autoStatusUpdate(workspaceId: string, entityId: string, entityTyp
 
       if (error) throw error;
 
-      // Rule: If prompt was just copied, move to "in_progress"
-      if (prompt.status === 'todo') {
-        await supabase
-          .from('prompts')
-          .update({ 
-            status: 'in_progress',
-            updated_at: new Date().toISOString()
-          })
-          .eq('id', entityId);
+      // Rule: If prompt was just copied, move to "in_progress" - DISABLED
+      // if (prompt.status === 'todo') {
+      //   await supabase
+      //     .from('prompts')
+      //     .update({ 
+      //       status: 'in_progress',
+      //       updated_at: new Date().toISOString()
+      //     })
+      //     .eq('id', entityId);
 
-        updatedEntities.push({
-          id: entityId,
-          type: 'prompt',
-          old_status: 'todo',
-          new_status: 'in_progress',
-          reason: 'Auto-updated on copy action'
-        });
-      }
+      //   updatedEntities.push({
+      //     id: entityId,
+      //     type: 'prompt',
+      //     old_status: 'todo',
+      //     new_status: 'in_progress',
+      //     reason: 'Auto-updated on copy action'
+      //   });
+      // }
     } else if (entityType === 'epic') {
       // Auto-update epic status based on prompt completion rates
       const { data: epic, error } = await supabase
@@ -225,13 +225,13 @@ async function automateTaskTransitions(workspaceId: string, entityId: string, en
       let statusChanged = false;
       let reason = '';
 
-      // Rule 1: "To Do" → "In Progress" when Cursor agent starts
-      if (prompt.status === 'todo' && prompt.cursor_agent_id && 
-          (prompt.cursor_agent_status === 'RUNNING' || prompt.cursor_agent_status === 'CREATING')) {
-        updates.status = 'in_progress';
-        statusChanged = true;
-        reason = 'Cursor agent started working on task';
-      }
+      // Rule 1: "To Do" → "In Progress" when Cursor agent starts - DISABLED
+      // if (prompt.status === 'todo' && prompt.cursor_agent_id && 
+      //     (prompt.cursor_agent_status === 'RUNNING' || prompt.cursor_agent_status === 'CREATING')) {
+      //   updates.status = 'in_progress';
+      //   statusChanged = true;
+      //   reason = 'Cursor agent started working on task';
+      // }
 
       // Rule 2: "In Progress" → "Done" when PR is merged
       if ((prompt.status === 'in_progress' || prompt.status === 'pr_created') && 


### PR DESCRIPTION
Disable automatic status changes to "In progress" for prompts to provide users with manual control.

Previously, prompts would automatically transition to "in_progress" when copied or when a Cursor agent started working on them. This change comments out the logic responsible for these automatic transitions in both the frontend and backend workflow automation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1a2f266-a92c-4930-b027-2967f522550b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1a2f266-a92c-4930-b027-2967f522550b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

